### PR TITLE
feat: Añade un botón flotante de WhatsApp.

### DIFF
--- a/frontend/css/components/whatsapp.css
+++ b/frontend/css/components/whatsapp.css
@@ -1,0 +1,54 @@
+/* ================================================
+   WHATSAPP FLOATING BUTTON
+   ================================================ */
+
+.whatsapp-float {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+  width: 50px;
+  height: 50px;
+  background: #25d366;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s ease;
+  cursor: pointer;
+  text-decoration: none;
+  border: none;
+}
+
+.whatsapp-float:hover {
+  transform: scale(1.1);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+.whatsapp-float:active {
+  transform: scale(0.95);
+}
+
+.whatsapp-float i {
+  color: white;
+  font-size: 24px;
+  line-height: 1;
+  display: block;
+  margin: 0;
+  padding: 0;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .whatsapp-float {
+    width: 45px;
+    height: 45px;
+    bottom: 15px;
+    right: 15px;
+  }
+
+  .whatsapp-float i {
+    font-size: 20px;
+  }
+}

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -34,3 +34,4 @@
 @import url('./pages/cuenta.css');
 @import url('./pages/wishlist.css');
 @import url('./pages/privacidad.css');
+@import url('./components/whatsapp.css');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -507,6 +507,11 @@
   <script src="js/pages/wishlist.js"></script>
   <script src="js/pages/catalogo.js"></script>
 
+  <!-- WhatsApp Button -->
+  <a href="https://wa.me/56964167930" class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp">
+    <i class="fab fa-whatsapp"></i>
+  </a>
+
 
 </body>
 

--- a/frontend/pages/carrito/index.html
+++ b/frontend/pages/carrito/index.html
@@ -250,6 +250,12 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../../js/components/navbar.js"></script>
     <script src="../../js/pages/carrito.js"></script>
+
+    <!-- WhatsApp Button -->
+    <a href="https://wa.me/56964167930" class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp">
+        <i class="fab fa-whatsapp"></i>
+    </a>
+
 </body>
 
 </html>

--- a/frontend/pages/catalogo/index.html
+++ b/frontend/pages/catalogo/index.html
@@ -301,7 +301,11 @@
   <script src="../../js/pages/wishlist.js"></script>
   <script src="../../js/utils/api.js"></script>
   <script src="../../js/pages/catalogo.js"></script>
-  
+
+  <!-- WhatsApp Button -->
+  <a href="https://wa.me/56964167930" class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp">
+    <i class="fab fa-whatsapp"></i>
+  </a>
 
 
 </body>

--- a/frontend/pages/checkout/index.html
+++ b/frontend/pages/checkout/index.html
@@ -273,6 +273,12 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
     <script src="../../js/components/navbar.js"></script>
     <script src="../../js/pages/checkout.js"></script>
+
+    <!-- WhatsApp Button -->
+    <a href="https://wa.me/56964167930" class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp">
+        <i class="fab fa-whatsapp"></i>
+    </a>
+
 </body>
 
 </html>

--- a/frontend/pages/producto/index.html
+++ b/frontend/pages/producto/index.html
@@ -188,6 +188,12 @@
     <script src="../../js/utils/script.js"></script>
     <script src="../../js/pages/wishlist.js"></script>
     <script src="../../js/pages/productos.js"></script>
+
+    <!-- WhatsApp Button -->
+    <a href="https://wa.me/56964167930" class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp">
+        <i class="fab fa-whatsapp"></i>
+    </a>
+
 </body>
 
 </html>

--- a/frontend/pages/wishlist/index.html
+++ b/frontend/pages/wishlist/index.html
@@ -229,6 +229,11 @@
   <script src="../../js/components/navbar.js"></script>
   <script src="../../js/pages/wishlist.js"></script>
 
+  <!-- WhatsApp Button -->
+  <a href="https://wa.me/56964167930" class="whatsapp-float" target="_blank" aria-label="Contactar por WhatsApp">
+    <i class="fab fa-whatsapp"></i>
+  </a>
+
 </body>
 
 </html>


### PR DESCRIPTION
- Añade un botón flotante de WhatsApp a todas las páginas principales (inicio, catálogo, lista de deseos, producto, carrito, pago).
- Crea un componente CSS dedicado con diseño adaptable.
- El botón es más pequeño (50 px) y solo se agranda al pasar el cursor.
- Usa el color verde oficial de WhatsApp (#25d366).
- Icono correctamente centrado con transiciones suaves.