### PR TITLE
Fix wishlist bug: Usar el ID de producto correcto en lugar del indefinido idProducto

### DIFF
--- a/frontend/js/pages/catalogo.js
+++ b/frontend/js/pages/catalogo.js
@@ -59,6 +59,7 @@ document.addEventListener("DOMContentLoaded", () => {
      * Crea el HTML de una card de producto
      */
     function crearCardProducto(producto) {
+        
         // Determinar estado del stock
         let stockBadge = "";
         if (producto.stock === 0 || producto.estadoStock === "AGOTADO") {
@@ -113,7 +114,7 @@ document.addEventListener("DOMContentLoaded", () => {
         
         return `
             <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
-                <div class="product-card" data-id="${producto.id || producto.idProducto}">
+                <div class="product-card" data-id="${producto.id}">
                     ${descuentoBadge}
                     
                     <div class="product-card__image">
@@ -121,7 +122,7 @@ document.addEventListener("DOMContentLoaded", () => {
                              alt="${producto.nombre}" 
                              loading="lazy"
                                onerror="this.src='${fallbackLogo}'">
-                        <button class="wishlist-btn-card" data-id="${producto.idProducto}" aria-label="Agregar a wishlist">
+                        <button class="wishlist-btn-card" data-id="${producto.id}" aria-label="Agregar a wishlist">
                             <i class="far fa-heart"></i>
                         </button>
                     </div>
@@ -141,7 +142,7 @@ document.addEventListener("DOMContentLoaded", () => {
                         
                         <div class="product-card__actions">
                             <button class="btn btn--primary btn-ver-detalle" 
-                                    data-id="${producto.id || producto.idProducto}">
+                                    data-id="${producto.id}">
                                 Ver detalle
                             </button>
                         </div>
@@ -351,7 +352,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (existe) {
             existe.cantidad += 1;
         } else {
-            const producto = todosLosProductos.find(p => (p.id || p.idProducto) == productoId);
+            const producto = todosLosProductos.find(p => p.id == productoId);
             if (producto) {
                 carrito.push({
                     id: productoId,


### PR DESCRIPTION


- Se cambiaron los atributos data-id en las tarjetas de producto para usar producto.id en lugar de producto.idProducto
- Se corrigieron los botones de la lista de deseos para identificar correctamente los productos individuales
- Se eliminaron las declaraciones de depuración console.log